### PR TITLE
fix handling of empty "extras" during project mapping

### DIFF
--- a/keystone/federation/utils.py
+++ b/keystone/federation/utils.py
@@ -716,17 +716,21 @@ class RuleProcessor(object):
                 k: self._expand_listlike(v)
                 for k, v in project.get('extra', {}).items()
             }
-            project_dicts.extend([{
-                'name': p_name,
-                'extra': {
+            for i, p_name in enumerate(project_names):
+                extra = {
                     k: (extras[i] if len(extras) > 1 else extras[0]) or ''
                     for k, extras in project_extras.items()
-                },
-                'roles': [
-                    {'name': r_name}
-                    for r_name in role_names_list
-                ],
-            } for i, p_name in enumerate(project_names)])
+                }
+                tmp_dict = {
+                    'name': p_name,
+                    'roles': [
+                        {'name': r_name}
+                        for r_name in role_names_list
+                    ],
+                }
+                if extra:
+                    tmp_dict.update({'extra': extra})
+                project_dicts.append(tmp_dict)
         return project_dicts
 
     def _expand_listlike(self, value):

--- a/keystone/tests/unit/contrib/federation/test_utils.py
+++ b/keystone/tests/unit/contrib/federation/test_utils.py
@@ -941,6 +941,24 @@ class MappingRuleEngineTests(unit.BaseTestCase):
         self.assertValidMappedUserObject(values)
         self.assertEqual(expected_projects, values['projects'])
 
+    def test_mapping_projects_mapped_extra(self):
+        mapping = mapping_fixtures.MAPPING_PROJECTS_MAPPED_NAME_AND_ROLES_AND_EXTRA
+        assertion = mapping_fixtures.EMPLOYEE_ASSERTION_MULTIPLE_GROUP_TYPES_EXTRA
+        rp = mapping_utils.RuleProcessor(FAKE_MAPPING_ID, mapping['rules'])
+        values = rp.process(assertion)
+        expected_projects = [
+            {
+                "name": "BuildingX",
+                "roles": [{"name": "member"}],
+                "extra": {"nickname": "BuildingXNick"}
+            },
+            {
+                "name": "BuildingY",
+                "roles": [{"name": "member"}],
+                "extra": {"nickname": ""}
+            }
+        ]
+        self.assertEqual(expected_projects, values['projects'])
 
 class TestUnicodeAssertionData(unit.BaseTestCase):
     """Ensure that unicode data in the assertion headers works.

--- a/keystone/tests/unit/mapping_fixtures.py
+++ b/keystone/tests/unit/mapping_fixtures.py
@@ -1603,6 +1603,16 @@ EMPLOYEE_ASSERTION_MULTIPLE_GROUP_TYPES = {
     'orgPersonBuilding': 'BuildingX;BuildingY'
 }
 
+EMPLOYEE_ASSERTION_MULTIPLE_GROUP_TYPES_EXTRA = {
+    'Email': 'tim@example.com',
+    'UserName': 'tbo',
+    'FirstName': 'Tim',
+    'LastName': 'Bo',
+    'orgPersonType': 'Developer;Employee',
+    'orgPersonBuilding': 'BuildingX;BuildingY',
+    'orgPersonBuildingNickName': 'BuildingXNick;'
+}
+
 EMPLOYEE_ASSERTION_PREFIXED = {
     'PREFIX_Email': 'tim@example.com',
     'PREFIX_UserName': 'tbo',
@@ -1972,6 +1982,38 @@ MAPPING_PROJECT_MAPPED_NAME_AND_ROLES = {
                 },
                 {
                     "type": "orgPersonType"
+                }
+            ]
+        }
+    ]
+}
+
+MAPPING_PROJECTS_MAPPED_NAME_AND_ROLES_AND_EXTRA = {
+    "rules": [
+        {
+            "local": [
+                {
+                    "user": {
+                        "name": "{0}",
+                    }
+                },
+                {
+                    "projects": [
+                        {"name": "{1}",
+                         "extra": {"nickname": "{2}"},
+                         "roles": [{"name": "member"}]}
+                    ]
+                }
+            ],
+            "remote": [
+                {
+                    "type": "UserName"
+                },
+                {
+                    "type": "orgPersonBuilding"
+                },
+                {
+                    "type": "orgPersonBuildingNickName"
                 }
             ]
         }


### PR DESCRIPTION
fix handling of empty "extras" during project mapping
    
Our modification to handle "extra" project properties during mapping
caused the "extra" parameter to be added in all cases, even when empty,
breaking existing unit-tests.
    
This is a simple refactor to avoid adding the property when it is
otherwise unused, preserving the upstream unit-tests, as well as a
new unit-test to specifically exercise the "extra" feature.
    
(cherry picked from commit 796f0fa282cf576ba695aa0202d1204ff5b48b6b)